### PR TITLE
Fancied up create.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # metrics-charts
+
+These are the helm charts used by the DevOps team to deploy Ceres.
+
+# Using for test/dev
+For testing/dev you can simply use the `create.sh` script to deploy all of the
+apps need to run CERES.
+
+
+
+### Notes
+Good luck and May the Force be with you!

--- a/helm-ceres-influxdb/Chart.yaml
+++ b/helm-ceres-influxdb/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 name: helm-ceres-influxdb
 version: 0.2.1
 description: Scalable datastore for metrics, events, and real-time analytics.
+appVersion: 1.6
 keywords:
 - influxdb
 - database


### PR DESCRIPTION
# What
The `create.sh` script now ensures that helm is installed and allows for namespace specific deployments.

## This script should NOT be used in prod